### PR TITLE
Recommend using `swiftly` in `AudioWorkstation/README.md`

### DIFF
--- a/AudioWorkstation/README.md
+++ b/AudioWorkstation/README.md
@@ -11,43 +11,8 @@ It is split into three packages: `Guest` with Wasm modules built with Embedded S
 
 ## Requirements
 
-WebAssembly support in Swift is available for preview in latest Trunk Development (main) snapshots at
-[swift.org/download](https://www.swift.org/download).
-
-### macOS
-
-1. Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12).
-2. Verify selected Xcode path by running `xcode-select -p` in the terminal. If the incorrect Xcode is selected, follow
-the steps provided in ["How do I select the default version of Xcode"](https://developer.apple.com/library/archive/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-HOW_DO_I_SELECT_THE_DEFAULT_VERSION_OF_XCODE_TO_USE_FOR_MY_COMMAND_LINE_TOOLS_) section of
-["Building from the Command Line with Xcode FAQ"](https://developer.apple.com/library/archive/technotes/tn2339/_index.html).
-3. Download latest `main` development snapshot, you can use [`DEVELOPMENT-SNAPSHOT-2024-04-01-a`](https://download.swift.org/development/xcode/swift-DEVELOPMENT-SNAPSHOT-2024-04-01-a/swift-DEVELOPMENT-SNAPSHOT-2024-04-01-a-osx.pkg) or a later version.
-4. Run the downloaded installer. Select "Install for me only" option during installation.
-5. Select the newly installed snapshot in terminal:
-
-```sh
-export TOOLCHAINS=$(plutil -extract CFBundleIdentifier raw \
-  ~/Library/Developer/Toolchains/swift-latest.xctoolchain/Info.plist)
-```
-
-### Linux
-
-Follow Linux-specific instructions provided on [swift.org/install](https://www.swift.org/install/#linux) to install the
-latest development toolchain for your specific distribution.
-
-### Docker
-
-1. Start a docker container in a clone of this repository using the nightly swiftlang Ubuntu image, with a `/root/build`
-mount to the current directory:
-
-```sh
-docker run --rm -it -v $(pwd):/root/build swiftlang/swift:nightly-jammy /bin/bash
-```
-
-2. Navigate to the package directory within the container:
-
-```sh
-cd /root/build
-```
+WebAssembly support in Swift is available for preview in latest 6.2 Development snapshots at
+[swift.org/download](https://www.swift.org/download). Follow instructions on that page for installing `swiftly` and run `swiftly install 6.2-snapshot` after that.
 
 ## How to Build and Run
 


### PR DESCRIPTION
Simplified installation instructions to recommend `swiftly` instead of installing toolchains manually.