### PR TITLE
Disable broken CI configurations in `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       enable_embedded_wasm_sdk_build: true
+      wasm_exclude_swift_versions: '[{"swift_version": "nightly-6.2"}]'
       enable_linux_checks: false
       enable_macos_checks: false
       enable_windows_checks: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,7 +29,6 @@ jobs:
     name: Build WebGPU Demo
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
-      enable_embedded_wasm_sdk_build: true
       wasm_exclude_swift_versions: '[{"swift_version": "nightly-6.2"}]'
       enable_linux_checks: false
       enable_macos_checks: false

--- a/WebGPUDemo/Package.resolved
+++ b/WebGPUDemo/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "8b1d9dc30426eb64ddd75cf52781d1b481727ea88d6e78f3147f650919d2e2a6",
+  "originHash" : "76c1e4088705907beec839fa123b640884ec89a62e0a63341defa9bd1abbd692",
   "pins" : [
     {
       "identity" : "javascriptkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftwasm/JavaScriptKit.git",
       "state" : {
-        "revision" : "7510b04120bb26a25dd287af71de47065d577c7e",
-        "version" : "0.33.1"
+        "revision" : "0b785610d170a0cbb4777ea379cb7221fc82c401"
       }
     },
     {

--- a/WebGPUDemo/Package.swift
+++ b/WebGPUDemo/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ),
     .package(
       url: "https://github.com/swiftwasm/JavaScriptKit.git",
-      from: "0.33.1",
+      revision: "0b785610d170a0cbb4777ea379cb7221fc82c401",
     ),
   ],
   targets: [

--- a/WebGPUDemo/README.md
+++ b/WebGPUDemo/README.md
@@ -9,16 +9,6 @@ the Swift SDK in the following command to the version that matches your installe
 swift package --swift-sdk swift-6.2-RELEASE_wasm js --use-cdn
 ```
 
-If you'd like to produce a smaller binary (under 400 kB), you'll have to use
-`swift-DEVELOPMENT-SNAPSHOT-2025-08-11` or later development snapshot of the `main` Swift toolchain
-branch. Earlier versions (including Swift 6.2) have no support for `async` functions in Embedded Swift,
-which is required for WebGPU setup. Use the following command to build with Embedded Swift (update for
-your installed toolchain version if needed):
-
-```
-swift package --swift-sdk swift-DEVELOPMENT-SNAPSHOT-2025-08-11-a_wasm-embedded js --use-cdn -c release
-```
-
 WebGPU is enabled by default in Safari 26. Safari 17 and 18 require enabling
 WebGPU feature flag as shown on the screenshot:
 

--- a/WebGPUDemo/README.md
+++ b/WebGPUDemo/README.md
@@ -1,12 +1,12 @@
 # WebGPU Example
 
-Install Swift 6.2 development snapshot and Swift SDK for Wasm by following
-https://www.swift.org/documentation/articles/wasm-getting-started.html.
+Install Swift 6.2 (or later version) and a corresponding Swift SDK for Wasm by following
+["Getting Started with Swift SDKs for WebAssembly" article](https://www.swift.org/documentation/articles/wasm-getting-started.html).
 
 Build with the installed Swift SDK using JavaScriptKit's `PackageToJSPlugin` plugin. Make sure to update
-the Swift SDK in the following command to the version that matches your installed swift.org toolchain.
+the Swift SDK in the following command to the version that matches your installed Swift toolchain.
 ```
-swift package --swift-sdk swift-6.2-DEVELOPMENT-SNAPSHOT-2025-06-17-a_wasm js --use-cdn
+swift package --swift-sdk swift-6.2-RELEASE_wasm js --use-cdn
 ```
 
 If you'd like to produce a smaller binary (under 400 kB), you'll have to use
@@ -19,7 +19,7 @@ your installed toolchain version if needed):
 swift package --swift-sdk swift-DEVELOPMENT-SNAPSHOT-2025-08-11-a_wasm-embedded js --use-cdn -c release
 ```
 
-WebGPU is enabled by default in beta and technical preview versions of Safari. Safari 17 and 18 require enabling
+WebGPU is enabled by default in Safari 26. Safari 17 and 18 require enabling
 WebGPU feature flag as shown on the screenshot:
 
 <img width="833" alt="Safari Feature Flags settings tab with WebGPU enabled" src="https://github.com/user-attachments/assets/7d0453ab-da51-4a6e-85da-dc466cf775be" />


### PR DESCRIPTION
`AudioWorkstation/Guest` triggers an assertion in 6.2 release with Embedded Swift. Also, we have to pin JavaScriptKit revision to include https://github.com/swiftwasm/JavaScriptKit/pull/443.