### PR TITLE
Add `JSONBridge` example

### DIFF
--- a/JSONBridge/.editorconfig
+++ b/JSONBridge/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+xcode_trim_whitespace_on_empty_lines = true

--- a/JSONBridge/.gitignore
+++ b/JSONBridge/.gitignore
@@ -1,0 +1,5 @@
+.build
+node_modules
+test-results
+playwright-report
+package-lock.json

--- a/JSONBridge/Package.resolved
+++ b/JSONBridge/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "f166b811140152b12c869f688c39b8f9f3b4313574c199a21d95e4d9885c84eb",
+  "pins" : [
+    {
+      "identity" : "javascriptkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftwasm/JavaScriptKit.git",
+      "state" : {
+        "revision" : "453b841f4fd78e6001c576f524b5bc597a9373bd",
+        "version" : "0.54.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/JSONBridge/Package.swift
+++ b/JSONBridge/Package.swift
@@ -1,0 +1,40 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import PackageDescription
+
+let package = Package(
+  name: "JSONBridge",
+  dependencies: [
+    .package(
+      url: "https://github.com/swiftwasm/JavaScriptKit.git",
+      from: "0.54.1"
+    )
+  ],
+  targets: [
+    .executableTarget(
+      name: "JSONBridge",
+      dependencies: [
+        .product(name: "JavaScriptKit", package: "JavaScriptKit")
+      ],
+      swiftSettings: [
+        .enableExperimentalFeature("Extern")
+      ],
+      plugins: [
+        .plugin(name: "BridgeJS", package: "JavaScriptKit")
+      ]
+    )
+  ]
+)

--- a/JSONBridge/README.md
+++ b/JSONBridge/README.md
@@ -1,0 +1,43 @@
+# JSONBridge Example
+
+Demonstrates how the result of JavaScript's `JSON.parse` is mapped onto a static Swift type
+using [BridgeJS](https://swiftpackageindex.com/swiftwasm/JavaScriptKit/documentation/javascriptkit/introducing-bridgejs)
+from JavaScriptKit, built with Embedded Swift for WebAssembly.
+
+`Sources/JSONBridge/main.swift` declares a `@JSClass struct User` whose `@JSGetter` properties read
+fields off a parsed JavaScript object as typed Swift values, and imports `globalThis.JSON.parse`
+statically as a `@JSClass(from: .global)` namespace. `try JSON.parse(jsonString)` returns a `User`,
+and `try user.name` / `try user.age` / `try user.nickname` read its fields with full Swift types and
+no dynamic member lookup.
+
+## Building
+
+Install Swift and a matching Wasm embedded Swift SDK by following
+["Getting Started with Swift SDKs for WebAssembly"](https://www.swift.org/documentation/articles/wasm-getting-started.html).
+Update the Swift SDK name to match your installed toolchain (`swift sdk list`), then build with the
+JavaScriptKit PackageToJS plugin:
+
+```
+# Latest 6.3 release:
+swift package --swift-sdk swift-6.3.2-RELEASE_wasm-embedded js --use-cdn -c release
+
+# Or a recent `main` development snapshot:
+swift package --swift-sdk swift-DEVELOPMENT-SNAPSHOT-2026-05-27-a_wasm-embedded js --use-cdn -c release
+```
+
+## Running
+
+Start an HTTP server in this directory and open it in a browser:
+
+```
+npx serve -l 8080
+```
+
+then open the printed URL (http://localhost:8080). The page renders:
+
+```
+name=Ada, age=36, nickname=<none>
+name=Tim, age=48, nickname=Spark
+name=Bo, age=29, nickname=<none>
+```
+

--- a/JSONBridge/Sources/JSONBridge/main.swift
+++ b/JSONBridge/Sources/JSONBridge/main.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import JavaScriptKit
+
+// The static Swift type that the parsed JSON object's fields map onto. Each `@JSGetter`
+// reads a property off the underlying JavaScript object as a statically typed Swift value.
+@JSClass
+struct User {
+  @JSGetter var name: String
+  // JSON has no integer type — every JSON number is a JavaScript `Number`, i.e. a `Double`.
+  @JSGetter var age: Double
+  // A JSON `null`, or a property absent from the object, maps to Swift `nil`.
+  @JSGetter var nickname: Optional<String>
+}
+@JSClass(from: .global)
+struct JSON {
+  @JSFunction static func parse(_ text: String) throws(JSException) -> User
+}
+
+private func describe(_ user: User) throws(JSException) -> String {
+  "name=\(try user.name), age=\(Int(try user.age)), nickname=\(try user.nickname ?? "<none>")"
+}
+
+// Exported to JavaScript as `exports.run()`. Parses three JSON strings and maps each onto the
+// static `User` type: a `null` nickname, a present nickname, and a fixture that omits the
+// nickname entirely while carrying a fractional `age` (truncated by the `Int(...)` narrowing).
+@JS public func run() throws(JSException) -> String {
+  let nullNickname = try JSON.parse(#"{"name":"Ada","age":36,"nickname":null}"#)
+  let presentNickname = try JSON.parse(#"{"name":"Tim","age":48,"nickname":"Spark"}"#)
+  let missingNickname = try JSON.parse(#"{"name":"Bo","age":29.5}"#)
+  return try [
+    describe(nullNickname),
+    describe(presentNickname),
+    describe(missingNickname),
+  ].joined(separator: "\n")
+}

--- a/JSONBridge/Sources/JSONBridge/main.swift
+++ b/JSONBridge/Sources/JSONBridge/main.swift
@@ -12,7 +12,7 @@
 
 import JavaScriptKit
 
-// The static Swift type that the parsed JSON object's fields map onto. Each `@JSGetter`
+// The Swift type that the parsed JSON object's fields map onto. Each `@JSGetter`
 // reads a property off the underlying JavaScript object as a statically typed Swift value.
 @JSClass
 struct User {

--- a/JSONBridge/index.html
+++ b/JSONBridge/index.html
@@ -1,0 +1,20 @@
+<!-- This source file is part of the Swift open source project
+
+Copyright (c) 2026 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors -->
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>JSON.parse → Swift type via BridgeJS</title>
+    <script type="module" src="./index.js"></script>
+  </head>
+  <body>
+    <h1>JSON.parse → Swift type via BridgeJS</h1>
+    <pre id="result">Loading...</pre>
+  </body>
+</html>

--- a/JSONBridge/index.js
+++ b/JSONBridge/index.js
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import { init } from "./.build/plugins/PackageToJS/outputs/Package/index.js";
+
+// `JSON` resolves from `globalThis` via the `from: .global` glue, so `getImports` is empty.
+const { exports } = await init({ getImports: () => ({}) });
+
+document.getElementById("result").textContent = exports.run();


### PR DESCRIPTION
Added a `JSONBridge` example demonstrating how the result of JavaScript's `JSON.parse` maps onto a Swift type via BridgeJS built with Embedded Swift for WebAssembly. `Sources/JSONBridge/main.swift` declares a `@JSClass struct User` whose `@JSGetter` properties read typed fields, imports `globalThis.JSON.parse` statically as a `@JSClass(from: .global)` namespace, and exports `run()`, which parses three fixtures exercising present, `null`, and absent `nickname` values plus `Double` to `Int` narrowing. It depends on JavaScriptKit `0.54.1`, builds with the `PackageToJS` plugin via `swift package ... js --use-cdn`.