### PR TITLE
Give the WasmGuide landing page a display name and abstract

### DIFF
--- a/Sources/WasmGuide/WasmGuide.docc/WasmGuide.md
+++ b/Sources/WasmGuide/WasmGuide.docc/WasmGuide.md
@@ -1,6 +1,6 @@
 # ``WasmGuide``
 
-Run Swift in the browser and beyond: interoperate with JavaScript, port existing code, and handle concurrency.
+Run Swift in the browser and beyond: interoperate with JavaScript and port existing code.
 
 @Metadata {
     @DisplayName("Swift for WebAssembly")

--- a/Sources/WasmGuide/WasmGuide.docc/WasmGuide.md
+++ b/Sources/WasmGuide/WasmGuide.docc/WasmGuide.md
@@ -1,6 +1,10 @@
-# Swift for WebAssembly Guide
+# ``WasmGuide``
 
-This guide explores advanced topics for developing WebAssembly applications with Swift.
+Run Swift in the browser and beyond: interoperate with JavaScript, port existing code, and handle concurrency.
+
+@Metadata {
+    @DisplayName("Swift for WebAssembly")
+}
 
 For initial setup, building your first application, and editor configuration, please
 refer to the official [Getting Started with Swift SDKs for WebAssembly](https://www.swift.org/documentation/articles/wasm-getting-started.html) article on Swift.org.


### PR DESCRIPTION
## Motivation

In the aggregated swift.org documentation, the WebAssembly guide's landing page renders with the smashed-together module symbol name (`WasmGuide`) and no abstract. The root article used a plain-text heading (`# Swift for WebAssembly Guide`), which detaches it from the module symbol, so the built module page had no abstract and none of the article content.

## Changes

- Switch the landing page heading to the module symbol reference (```WasmGuide```) so the article's abstract and content attach to the module page.
- Add `@Metadata { @DisplayName("Swift for WebAssembly") }` so the page and navigation read as "Swift for WebAssembly" instead of "WasmGuide".
- Add a concise abstract: "Run Swift in the browser and beyond: interoperate with JavaScript, port existing code, and handle concurrency."

## Validation

`swift package generate-documentation --target WasmGuide --analyze --warnings-as-errors` builds successfully. The generated module page now shows the title "Swift for WebAssembly" and the abstract.